### PR TITLE
Replace Closure to callable in RetryAcquireTrait::retryAcquire()

### DIFF
--- a/src/RetryAcquireTrait.php
+++ b/src/RetryAcquireTrait.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Yiisoft\Mutex;
 
-use Closure;
-
 /**
  * Allows retrying acquire with a certain timeout.
  */
@@ -25,7 +23,7 @@ trait RetryAcquireTrait
         return $new;
     }
 
-    private function retryAcquire(int $timeout, Closure $callback): bool
+    private function retryAcquire(int $timeout, callable $callback): bool
     {
         $start = microtime(true);
         do {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | -

If the code of the callback function is large, can wrap it with an invocable class.