### PR TITLE
Throw of exception if retry delay less one millisecond

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## 1.1.1 under development
 
-- no changes in this release.
+- Enh #48 Throw an `InvalidArgumentException` if the retry delay is less than one millisecond (devanych)
 
 ## 1.1.0 October 19, 2021
 

--- a/src/RetryAcquireTrait.php
+++ b/src/RetryAcquireTrait.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Yiisoft\Mutex;
 
+use InvalidArgumentException;
+
 use function microtime;
 use function usleep;
 
@@ -12,6 +14,9 @@ use function usleep;
  */
 trait RetryAcquireTrait
 {
+    /**
+     * @psalm-var positive-int
+     */
     private int $retryDelay = 50;
 
     /**
@@ -24,6 +29,12 @@ trait RetryAcquireTrait
      */
     public function withRetryDelay(int $retryDelay): self
     {
+        if ($retryDelay < 1) {
+            throw new InvalidArgumentException(
+                "Retry delay value must be a positive number greater than zero, \"$retryDelay\" is received.",
+            );
+        }
+
         $new = clone $this;
         $new->retryDelay = $retryDelay;
         return $new;

--- a/tests/RetryAcquireTraitTest.php
+++ b/tests/RetryAcquireTraitTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Mutex\Tests;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Mutex\Tests\Mocks\RetryAcquireTraitMutex;
 
@@ -33,6 +34,20 @@ final class RetryAcquireTraitTest extends TestCase
             ->withRetryDelay(1000);
 
         $this->assertFalse($mutex->acquire(1));
+    }
+
+    public function testRetryAcquireThrowExceptionWithNotPositiveRetryDelay(): void
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped('usleep() is not reliable on Windows.');
+        }
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Retry delay value must be a positive number greater than zero, "0" is received.',
+        );
+
+        (new RetryAcquireTraitMutex(2))->withRetryDelay(0);
     }
 
     public function testImmutability(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -

If you do not throw an `InvalidArgumentException`, it will be thrown:

```
ValueError: usleep(): Argument #1 ($microseconds) must be greater than or equal to 0.
```
